### PR TITLE
Add hint component and camera guidance

### DIFF
--- a/apps/camNC/src/components/Hint.tsx
+++ b/apps/camNC/src/components/Hint.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export function Hint({ title, children }: { title?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div className="border-l-2 pl-2 mb-4 space-y-1">
+      <div className="text-sm">
+        {title && <p className="mb-1 font-medium">{title}</p>}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/camNC/src/setup/MarkerPositionsForm.tsx
+++ b/apps/camNC/src/setup/MarkerPositionsForm.tsx
@@ -3,6 +3,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@wbcnc/ui/components/button';
 import { Checkbox } from '@wbcnc/ui/components/checkbox';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@wbcnc/ui/components/form';
+import { Hint } from '@/components/Hint';
 import { Input } from '@wbcnc/ui/components/input';
 import { ExternalLink } from 'lucide-react';
 import { Control, useForm } from 'react-hook-form';
@@ -121,37 +122,33 @@ export function MarkerPositionsForm({ onConfirmed }: { onConfirmed: () => void }
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-        <div className="border-l-2 pl-2 mb-4 space-y-1">
-          <div className="text-sm">
-            <p className="mb-1 font-medium">Marker Placement</p>
-
-            <p className="mb-1">
-              You need to place 4 markers on or near the wasteboard so they're visible in the camera view. You can do this in either of the
-              following ways:
-            </p>
-            <ul className="list-disc list-inside space-y-1 ml-4">
-              <li>
-                Recommended: Add four small 40x40mm pockets to the wasteboard and place (3d) printed{' '}
-                <a href="/aruco.pdf" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">
-                  ArUco markers <ExternalLink className="size-4 inline-block" />
-                </a>{' '}
-                inside. They can be (re-)detected automatically (e.g. in case the camera or table moves). <br />
-                Pocketing gcode for 3.175mm (1/8in) endmill can be generated below for the positions entered.
-              </li>
-              <li>
-                Engrave{' '}
-                <a
-                  href="https://vector76.github.io/gcode_tpgen/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-500 hover:underline">
-                  Squareness marks <ExternalLink className="size-4 inline-block" />
-                </a>{' '}
-                on the wasteboard at the machine bounds. Then select those manually in the camera view (next step).
-              </li>
-            </ul>
-          </div>
-        </div>
+        <Hint title="Marker Placement">
+          <p className="mb-1">
+            You need to place 4 markers on or near the wasteboard so they're visible in the camera view. You can do this in either of the
+            following ways:
+          </p>
+          <ul className="list-disc list-inside space-y-1 ml-4">
+            <li>
+              Recommended: Add four small 40x40mm pockets to the wasteboard and place (3d) printed{' '}
+              <a href="/aruco.pdf" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">
+                ArUco markers <ExternalLink className="size-4 inline-block" />
+              </a>{' '}
+              inside. They can be (re-)detected automatically (e.g. in case the camera or table moves). <br />
+              Pocketing gcode for 3.175mm (1/8in) endmill can be generated below for the positions entered.
+            </li>
+            <li>
+              Engrave{' '}
+              <a
+                href="https://vector76.github.io/gcode_tpgen/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 hover:underline">
+                Squareness marks <ExternalLink className="size-4 inline-block" />
+              </a>{' '}
+              on the wasteboard at the machine bounds. Then select those manually in the camera view (next step).
+            </li>
+          </ul>
+        </Hint>
 
         <div className="space-y-4 mb-6">
           <FormField

--- a/apps/camNC/src/setup/video-source-selection/VideoSourceSelection.tsx
+++ b/apps/camNC/src/setup/video-source-selection/VideoSourceSelection.tsx
@@ -9,6 +9,7 @@ import {
 } from '@wbcnc/go2webrtc/url-helpers';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@wbcnc/ui/components/tabs';
 import { useMemo, useState } from 'react';
+import { Hint } from '@/components/Hint';
 
 import { VideoDimensions } from '@wbcnc/go2webrtc/video-source';
 import { ConnectDialog } from './ConnectDialog';
@@ -60,6 +61,34 @@ export function VideoSourceSelection({ value = '', onChange }: { value?: string;
 
   return (
     <>
+      <Hint title="Camera Setup">
+        <p className="mb-1">
+          Position a camera above the machine so the full working area is visible. Repurposing an old phone works well and you can 3D print
+          <a
+            href="https://makerworld.com/en/models/1455114-ceiling-top-down-phone-mount-with-ball-joint#profileId-1516416"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:underline mx-1">
+            this mount
+          </a>
+          for an easy setup.
+        </p>
+        <p className="mb-1">
+          A Reolink E1 Zoom is also suitable
+          <a
+            href="https://makerworld.com/en/models/1461605-reolink-e1-zoom-ceiling-down-mount-looking-down#profileId-1524062"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:underline mx-1">
+            (mount)
+          </a>
+          , but it requires running
+          <a href="https://github.com/AlexxIT/go2rtc" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline mx-1">
+            go2rtc
+          </a>
+          as a gateway, e.g. on a Raspberry&nbsp;Pi&nbsp;Zero.
+        </p>
+      </Hint>
       <Tabs className="w-full" value={sourceType} onValueChange={setSourceType}>
         <TabsList className="grid w-full grid-cols-4">
           <TabsTrigger value="webcam">Webcam</TabsTrigger>


### PR DESCRIPTION
## Summary
- create reusable `Hint` component in the camNC app
- replace hint block in MarkerPositionsForm with the new component
- show camera placement hint on URL entry step

## Testing
- `pnpm lint` *(fails: ESLint found too many warnings)*
- `pnpm test` *(fails: some tests error out)*

------
https://chatgpt.com/codex/tasks/task_e_68400876fa64832092af0d9999b98afa