### PR TITLE
Fix camera stream release in marker scanner

### DIFF
--- a/apps/camNC/src/hooks/useAutoScanMarkers.ts
+++ b/apps/camNC/src/hooks/useAutoScanMarkers.ts
@@ -99,7 +99,6 @@ class MarkerScannerService {
     this.proxy = proxy;
     this.cleanupFn = () => {
       worker.terminate();
-      videoTrack.stop();
       releaseVideoSource(this.camSource.url);
       readable.cancel?.().catch(() => undefined);
     };


### PR DESCRIPTION
## Summary
- avoid stopping shared camera track in `useAutoScanMarkers`
- remove debugging comments

## Testing
- `npx turbo run test --filter=@wbcnc/camNC...` *(fails: FluidNcClient ↔ FluidNcServer integration timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684af8c6b7948320a78cadedcc3bbbdc