### PR TITLE
Remove optional manual markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This repository is a pnpm/Turborepo workspace using TypeScript and React.
 ## Workflow
 
 - Use **pnpm** (Node >=18) for all package management tasks.
-- After making changes, run `pnpm run build`, `pnpm run lint` and `pnpm run test` from the repo root.
+- After making changes, run `pnpm run format`, `pnpm run build`, `pnpm run lint` and `pnpm run test` from the repo root.
   - These commands execute turborepo tasks across all packages.
 - Format TypeScript and Markdown files with Prettier using `pnpm run format`.
 - Keep generated files such as `routeTree.gen.ts` read-only; avoid editing them manually.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CamNC is a simple experimental web application that visualizes CNC G-code on a l
 
 - Overlay live G-code preview on a camera feed with perspective correction
 - Integrated calibration tool (OpenCV) to estimate camera intrinsics
-- Perspective-n-Point (PnP) pose estimation using machined wasteboard markers or ArUco markers
+- Perspective-n-Point (PnP) pose estimation using ArUco markers
 - Interactive zeroing and jogging via integration with FluidNC WebUI v3
 
 ## Requirements

--- a/apps/camNC/src/routes/setup/edit-settings.tsx
+++ b/apps/camNC/src/routes/setup/edit-settings.tsx
@@ -30,7 +30,6 @@ const innerSchema = z.object({
   machineBounds: z.array(z.number()).length(4),
   markerPosInCam: z.array(z.array(z.number()).length(2)).optional(),
   markerPositions: z.array(z.array(z.number()).length(3)).length(4),
-  useArucoMarkers: z.boolean(),
   arucoTagSize: z.number(),
 });
 
@@ -74,7 +73,6 @@ const schema = z.object({
         ),
         markerPositions: data.markerPositions.map(p => new Vector3(...p)),
         markerPosInCam: data.markerPosInCam?.map(p => new Vector2(...p)),
-        useArucoMarkers: data.useArucoMarkers,
         arucoTagSize: data.arucoTagSize,
       };
     }),
@@ -97,7 +95,6 @@ function calibToJson(data: ICamSource) {
       markerPositions: data.markerPositions?.map(p => p.toArray()),
 
       markerPosInCam: data.markerPosInCam?.map(p => [p.x, p.y]), //.map(p => p.toArray()),
-      useArucoMarkers: data.useArucoMarkers,
       arucoTagSize: data.arucoTagSize,
     },
     null,

--- a/apps/camNC/src/setup/MarkerBoundsButton.tsx
+++ b/apps/camNC/src/setup/MarkerBoundsButton.tsx
@@ -25,13 +25,12 @@ type MarginFormData = z.infer<typeof marginSchema>;
 
 interface MarkerBoundsButtonProps {
   bounds: Box2;
-  useArucoMarkers: boolean;
   arucoTagSize: number;
   onApply: (markers: Array<{ x: number; y: number; z: number }>) => void;
 }
 
-export function calculateDefaultMargin(useArucoMarkers: boolean, arucoTagSize: number): number {
-  return useArucoMarkers ? arucoTagSize / 2 + 5 : 0;
+export function calculateDefaultMargin(arucoTagSize: number): number {
+  return arucoTagSize / 2 + 5;
 }
 
 export function calculateMarkersWithMargin(bounds: Box2, margin: number, z = -3.2): Array<{ x: number; y: number; z: number }> {
@@ -43,9 +42,9 @@ export function calculateMarkersWithMargin(bounds: Box2, margin: number, z = -3.
   ];
 }
 
-export function MarkerBoundsButton({ bounds, useArucoMarkers, arucoTagSize, onApply }: MarkerBoundsButtonProps) {
+export function MarkerBoundsButton({ bounds, arucoTagSize, onApply }: MarkerBoundsButtonProps) {
   const [open, setOpen] = useState(false);
-  const defaultMargin = calculateDefaultMargin(useArucoMarkers, arucoTagSize);
+  const defaultMargin = calculateDefaultMargin(arucoTagSize);
 
   const form = useForm<MarginFormData>({
     defaultValues: { margin: defaultMargin },
@@ -62,7 +61,7 @@ export function MarkerBoundsButton({ bounds, useArucoMarkers, arucoTagSize, onAp
     setOpen(newOpen);
     if (newOpen) {
       // Reset form to current default when opening
-      form.reset({ margin: calculateDefaultMargin(useArucoMarkers, arucoTagSize) });
+      form.reset({ margin: calculateDefaultMargin(arucoTagSize) });
     }
   }
 
@@ -95,11 +94,7 @@ export function MarkerBoundsButton({ bounds, useArucoMarkers, arucoTagSize, onAp
                   <FormControl>
                     <Input {...field} type="number" placeholder={String(defaultMargin)} />
                   </FormControl>
-                  <p className="text-xs text-muted-foreground">
-                    {useArucoMarkers
-                      ? `Default: ${defaultMargin}mm (tag size/2 + 5mm clearance)`
-                      : 'Distance inward from machine bounds edges'}
-                  </p>
+                  <p className="text-xs text-muted-foreground">{`Default: ${defaultMargin}mm (tag size/2 + 5mm clearance)`}</p>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/camNC/src/setup/ThreePointSelectionStep.tsx
+++ b/apps/camNC/src/setup/ThreePointSelectionStep.tsx
@@ -142,7 +142,6 @@ export const ThreePointSelectionStep: React.FC<PointSelectionStepProps> = () => 
   const setMarkerPosInCam = useStore(state => state.camSourceSetters.setMarkerPosInCam);
   const navigate = useNavigate();
 
-
   // Handle saving points
   const handleSave = () => {
     const pointsToSave = markers.flatMap(m => m.corners);

--- a/apps/camNC/src/setup/ThreePointSelectionStep.tsx
+++ b/apps/camNC/src/setup/ThreePointSelectionStep.tsx
@@ -1,17 +1,15 @@
 import { UnskewedVideoMesh } from '@/calibration/UnskewTsl';
-import { Draggable } from '@/scene/Draggable';
 import { PresentCanvas } from '@/scene/PresentCanvas';
 import { updateCameraExtrinsics, useReprojectedMarkerPositions } from '@/store/store-p3p';
 import { Line, Text } from '@react-three/drei';
-import { ThreeEvent } from '@react-three/fiber';
 import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@wbcnc/ui/components/button';
 import { PageHeader } from '@wbcnc/ui/components/page-header';
 import { toast } from '@wbcnc/ui/components/sonner';
-import React, { Suspense, useEffect, useMemo, useState } from 'react';
+import React, { Suspense, useMemo, useState } from 'react';
 import * as THREE from 'three';
 import { Vector2, Vector3 } from 'three';
-import { useArucoConfig, useCamResolution, useStore } from '../store/store';
+import { useStore } from '../store/store';
 import { DetectArucosButton } from './DetectArucoButton';
 import { IMarker } from './detect-aruco';
 
@@ -42,18 +40,6 @@ const kPointLabels = [
   'Marker 2: near (xmax, ymax)',
   'Marker 3: near (xmax, ymin)',
 ];
-
-const NextPointHint: React.FC<{ pointCount: number }> = ({ pointCount }) => {
-  if (pointCount >= 4) {
-    return null;
-  }
-
-  const getNextPointLabel = () => {
-    return pointCount < 4 ? kPointLabels[pointCount] : null;
-  };
-
-  return <div>Select position of {getNextPointLabel()}</div>;
-};
 
 // A crosshair component to show at each point
 const Crosshair: React.FC<{
@@ -134,93 +120,6 @@ const videoToMeshCoords = (point: Vector2): Vector3 => {
   return new Vector3(point.x, point.y, -0.2);
 };
 
-// Component for manual point selection
-function ManualPointsScene({ points, setPoints }: { points: Vector2[]; setPoints: (points: Vector2[]) => void }) {
-  const videoSize = useCamResolution();
-  const [isDragging, setIsDragging] = useState(false);
-
-  // Handle placing a new point by clicking on the mesh
-  const handlePlacePoint = ({ point, ...e }: ThreeEvent<MouseEvent>) => {
-    if (points.length >= 4) return;
-
-    // Stop event propagation
-    e.stopPropagation();
-
-    setPoints([...points, new Vector2(point.x, point.y)]);
-  };
-
-  // Create line points for the calibration rectangle
-  const linePoints = useMemo(() => {
-    if (points.length !== 4) return [];
-
-    return [
-      ...points.map(p => videoToMeshCoords(p)),
-      videoToMeshCoords(points[0]), // Close the loop
-    ];
-  }, [points]);
-
-  // Handle point drag end
-  const handlePointDragEnd = (index: number, position: THREE.Vector3) => {
-    console.log('handlePointDragEnd', index, position);
-
-    const newPoints = [...points];
-    newPoints[index] = new Vector2(position.x, position.y);
-    setPoints(newPoints);
-  };
-
-  return (
-    <>
-      <UnskewedVideoMesh />
-
-      {/* Add a transparent plane overtop for click handling */}
-      <mesh position={[videoSize[0] / 2, videoSize[1] / 2, -0.005]} onClick={handlePlacePoint} rotation={[Math.PI, 0, 0]}>
-        <planeGeometry args={[videoSize[0], videoSize[1]]} />
-        <meshBasicMaterial transparent opacity={0} />
-      </mesh>
-
-      {/* Render points as draggable crosshairs */}
-      {points.map((point, index) => {
-        const pos = videoToMeshCoords(point);
-        return (
-          <Draggable
-            key={index}
-            position={pos}
-            rotation={[Math.PI, 0, 0]}
-            onDragStart={() => {
-              setIsDragging(true);
-            }}
-            onDragEnd={event => {
-              const worldPosition = new THREE.Vector3();
-              event.eventObject.getWorldPosition(worldPosition);
-              handlePointDragEnd(index, worldPosition);
-              setIsDragging(false);
-            }}>
-            <Crosshair position={[0, 0, 0]} color={index % 2 === 0 ? '#4287f5' : '#f54242'} size={25} />
-            <Suspense>
-              <Text
-                fontSize={40}
-                color="white"
-                outlineColor="black"
-                outlineWidth={1}
-                outlineBlur={1}
-                anchorX="center"
-                anchorY="middle"
-                position={[0, 50, 0]}>
-                {kPointLabels[index]}
-              </Text>
-            </Suspense>
-          </Draggable>
-        );
-      })}
-
-      {/* Draw connection lines between points */}
-      {points.length === 4 && !isDragging && <Line points={linePoints} color="yellow" lineWidth={2} />}
-
-      {!isDragging && <ReprojectedMachineBounds />}
-    </>
-  );
-}
-
 // Component for aruco marker visualization
 function ArucoPointsScene({ markers }: { markers: IMarker[] }) {
   return (
@@ -240,20 +139,13 @@ function ArucoPointsScene({ markers }: { markers: IMarker[] }) {
 
 export const ThreePointSelectionStep: React.FC<PointSelectionStepProps> = () => {
   const [markers, setMarkers] = useState<IMarker[]>([]);
-  const { useArucoMarkers } = useArucoConfig();
-  const [points, setPoints] = useState<Vector2[]>(useStore(state => state.camSource!.markerPosInCam) || []);
   const setMarkerPosInCam = useStore(state => state.camSourceSetters.setMarkerPosInCam);
   const navigate = useNavigate();
 
-  useEffect(() => {
-    if (!useArucoMarkers && points.length > 4) {
-      setPoints([]);
-    }
-  }, [useArucoMarkers, points]);
 
   // Handle saving points
   const handleSave = () => {
-    const pointsToSave = useArucoMarkers ? markers.flatMap(m => m.corners) : points;
+    const pointsToSave = markers.flatMap(m => m.corners);
 
     if (pointsToSave.length < 4) {
       console.error('Must select exactly 4 points');
@@ -272,7 +164,6 @@ export const ThreePointSelectionStep: React.FC<PointSelectionStepProps> = () => 
   };
 
   const handleReset = () => {
-    setPoints([]);
     setMarkers([]);
   };
 
@@ -288,8 +179,7 @@ export const ThreePointSelectionStep: React.FC<PointSelectionStepProps> = () => 
     setMarkers(detectedMarkers);
   };
 
-  const currentPointCount = useArucoMarkers ? markers.length * 4 : points.length;
-  const canSave = useArucoMarkers ? markers.length >= 4 : points.length >= 4;
+  const canSave = markers.length >= 4;
 
   return (
     <div className="w-full h-dvh flex flex-col gap-1 overflow-hidden">
@@ -297,12 +187,11 @@ export const ThreePointSelectionStep: React.FC<PointSelectionStepProps> = () => 
 
       <div className="flex-1 overflow-hidden">
         <PresentCanvas>
-          {useArucoMarkers ? <ArucoPointsScene markers={markers} /> : <ManualPointsScene points={points} setPoints={setPoints} />}
+          <ArucoPointsScene markers={markers} />
         </PresentCanvas>
       </div>
 
       <div className="absolute bottom-4 right-4 flex items-center justify-end gap-2 p-2 bg-white/80 rounded-lg shadow-sm">
-        {!useArucoMarkers && <NextPointHint pointCount={currentPointCount} />}
         {/* Action buttons for reset and save */}
         <DetectArucosButton onMarkersDetected={handleMarkersDetected} />
         <Button variant="secondary" onClick={handleReset}>

--- a/apps/camNC/src/store/store-p3p.ts
+++ b/apps/camNC/src/store/store-p3p.ts
@@ -18,17 +18,11 @@ function getInflatedMarkerPositions() {
   const camSource = useStore.getState().camSource;
   if (!camSource) throw new Error();
   const mp = camSource.markerPositions!;
-  if (camSource.useArucoMarkers) {
-    const as2 = camSource.arucoTagSize! / 2;
-    // Inflate aruco marker positions CW, top left first.
-    return mp.flatMap(m => {
-      return [new Vector3(-as2, as2, 0), new Vector3(as2, as2, 0), new Vector3(as2, -as2, 0), new Vector3(-as2, -as2, 0)].map(v =>
-        v.add(m)
-      );
-    });
-  } else {
-    return mp;
-  }
+  const as2 = camSource.arucoTagSize! / 2;
+  // Inflate aruco marker positions CW, top left first.
+  return mp.flatMap(m => {
+    return [new Vector3(-as2, as2, 0), new Vector3(as2, as2, 0), new Vector3(as2, -as2, 0), new Vector3(-as2, -as2, 0)].map(v => v.add(m));
+  });
 }
 
 function computeMarkerP3P() {

--- a/apps/camNC/src/store/store.ts
+++ b/apps/camNC/src/store/store.ts
@@ -4,7 +4,6 @@ import { Box2, Matrix3, Vector2, Vector3 } from 'three';
 import { create } from 'zustand';
 import { combine, devtools, persist, PersistStorage } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
-import { useShallow } from 'zustand/react/shallow';
 import { ParsedToolpath, parseGCode } from '../visualize/gcodeParsing';
 import { parseToolInfo } from '../visualize/guess-tools';
 
@@ -37,7 +36,6 @@ export interface ICamSource {
   extrinsics?: CameraExtrinsics;
   markerPositions?: Vector3[];
   // ArUco marker configuration
-  useArucoMarkers?: boolean;
   arucoTagSize?: number; // Size in mm of black border (excluding white border)
 }
 
@@ -138,11 +136,11 @@ export const useStore = create(devtools(persist(immer(combine(
         if (!state.camSource) throw new Error('configure source first');
         state.camSource.markerPositions = markers;
       }),
-      setArucoConfig: (useArucoMarkers: boolean, arucoTagSize: number) => set(state => {
-        if (!state.camSource) throw new Error('configure source first');
-        state.camSource.useArucoMarkers = useArucoMarkers;
-        state.camSource.arucoTagSize = arucoTagSize;
-      }),
+      setArucoTagSize: (arucoTagSize: number) =>
+        set(state => {
+          if (!state.camSource) throw new Error('configure source first');
+          state.camSource.arucoTagSize = arucoTagSize;
+        }),
     },
     setIsToolpathSelected: (isSelected: boolean) => set(state => {
       state.isToolpathSelected = isSelected;
@@ -213,14 +211,8 @@ export const useMarkerPositions = () => useStore(state => state.camSource!.marke
 // Hook to set marker positions
 export const useSetMarkerPositions = () => useStore(state => state.camSourceSetters.setMarkerPositions);
 // Hooks for ArUco configuration
-export const useArucoConfig = () =>
-  useStore(
-    useShallow(state => ({
-      useArucoMarkers: state.camSource?.useArucoMarkers ?? true,
-      arucoTagSize: state.camSource?.arucoTagSize ?? 30,
-    }))
-  );
-export const useSetArucoConfig = () => useStore(state => state.camSourceSetters.setArucoConfig);
+export const useArucoTagSize = () => useStore(state => state.camSource?.arucoTagSize ?? 30);
+export const useSetArucoTagSize = () => useStore(state => state.camSourceSetters.setArucoTagSize);
 
 export const useToolpath = () => useStore(state => state.toolpath);
 export const useHasToolpath = () => useToolpath() !== null;


### PR DESCRIPTION
## Summary
- always assume ArUco markers are used
- drop unused manual marker code and config
- update marker setup UI to always show ArUco options
- adjust README docs

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` *(fails: Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684d0427c7d883208a0ff48501d0fc11