### PR TITLE
fix heatmap overlay alignment

### DIFF
--- a/packages/camera-calibration/src/store/calibrationStore.ts
+++ b/packages/camera-calibration/src/store/calibrationStore.ts
@@ -141,14 +141,11 @@ const createCameraSlice: StateCreator<CalibrationState, [], [], CameraSlice> = (
       });
       throw new Error('Aspect‑ratio mismatch between provided and video element');
     }
-    if (maxResolution)
-      set({
-        frameWidth: maxResolution.width,
-        frameHeight: maxResolution.height,
-      });
-    else set({ frameWidth: vidRes.width, frameHeight: vidRes.height });
+    const frameRes = maxResolution ?? vidRes;
     set({
-      heatmapTracker: new GridHeatmapTracker(10, 10, vidRes.width, vidRes.height),
+      frameWidth: frameRes.width,
+      frameHeight: frameRes.height,
+      heatmapTracker: new GridHeatmapTracker(10, 10, frameRes.width, frameRes.height),
     });
   },
 


### PR DESCRIPTION
## Summary
- ensure GridHeatmapTracker uses working resolution

## Testing
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test` *(fails: FluidNcClient integration test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684d03b9297c83209c47b5cc60786559