### PR TITLE
feat(camNC) compute undistortion on GPU

### DIFF
--- a/apps/camNC/src/calibration/UnskewTsl.tsx
+++ b/apps/camNC/src/calibration/UnskewTsl.tsx
@@ -3,15 +3,13 @@ import { useCalibrationData, useCamResolution, useVideoUrl } from '@/store/store
 import { type ThreeElements } from '@react-three/fiber';
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
-import { useUnmapTextures } from './CameraShaderMaterial';
 import { useCameraTexture } from './useCameraTexture';
 
 // UndistortMesh component using Three.js Shading
 export function UnskewedVideoMesh({ ...props }: ThreeElements['mesh']) {
   const videoDimensions = useCamResolution();
   const videoTexture = useCameraTexture();
-
-  const [mapXTexture, mapYTexture] = useUnmapTextures();
+  const calibration = useCalibrationData();
 
   // Basic GLSL shader for undistortion
   const vertexShader = /* glsl */ `
@@ -24,36 +22,47 @@ export function UnskewedVideoMesh({ ...props }: ThreeElements['mesh']) {
   `;
 
   const fragmentShader = /* glsl */ `
-    // Basic GLSL fragment shader for undistortion
     uniform sampler2D videoTexture;
-    uniform sampler2D mapXTexture;
-    uniform sampler2D mapYTexture;
+    uniform mat3 cameraMatrix;
+    uniform mat3 newCameraMatrix;
+    uniform vec4 distCoeffs;
+    uniform float k3;
     uniform vec2 resolution;
 
     varying vec2 vUv;
 
+    vec2 undistort_uv(float u, float v) {
+      float fx_new = newCameraMatrix[0][0];
+      float fy_new = newCameraMatrix[1][1];
+      float cx_new = newCameraMatrix[2][0];
+      float cy_new = newCameraMatrix[2][1];
+      float nx = (u - cx_new) / fx_new;
+      float ny = (v - cy_new) / fy_new;
+      vec3 vec = vec3(nx, ny, 1.0);
+      float x = vec.x / vec.z;
+      float y = vec.y / vec.z;
+      float r2 = x * x + y * y;
+      float radial = 1.0 + distCoeffs.x * r2 + distCoeffs.y * r2 * r2 + k3 * r2 * r2 * r2;
+      float deltaX = 2.0 * distCoeffs.z * x * y + distCoeffs.w * (r2 + 2.0 * x * x);
+      float deltaY = distCoeffs.z * (r2 + 2.0 * y * y) + 2.0 * distCoeffs.w * x * y;
+      float xd = x * radial + deltaX;
+      float yd = y * radial + deltaY;
+      float fx = cameraMatrix[0][0];
+      float fy = cameraMatrix[1][1];
+      float cx = cameraMatrix[2][0];
+      float cy = cameraMatrix[2][1];
+      float srcX = fx * xd + cx;
+      float srcY = fy * yd + cy;
+      return vec2(srcX, srcY);
+    }
+
     void main() {
-      // Get the normalized (0-1) coordinates
-      vec2 uv = vUv;
-
-      // Get the remapped coordinates from the map textures
-      float mapX = texture2D(mapXTexture, vec2(uv.x, 1.0 - uv.y)).r;
-      float mapY = texture2D(mapYTexture, vec2(uv.x, 1.0 - uv.y)).r;
-
-      // Convert to normalized UV coordinates
-      vec2 remappedUv = vec2(
-        mapX / resolution.x,
-        mapY / resolution.y
-      );
-
-      // Sample the video texture at the remapped coordinates
-      // Check if coordinates are within the valid range (0-1)
+      vec2 pixel = vec2(vUv.x, 1.0 - vUv.y) * resolution;
+      vec2 src = undistort_uv(pixel.x, pixel.y) / resolution;
       vec4 color = vec4(0.0, 0.0, 0.0, 1.0);
-      if (remappedUv.x >= 0.0 && remappedUv.x <= 1.0 &&
-          remappedUv.y >= 0.0 && remappedUv.y <= 1.0) {
-        color = texture2D(videoTexture, vec2( remappedUv.x, 1.0 - remappedUv.y));
+      if (src.x >= 0.0 && src.x <= 1.0 && src.y >= 0.0 && src.y <= 1.0) {
+        color = texture2D(videoTexture, vec2(src.x, 1.0 - src.y));
       }
-
       gl_FragColor = color;
     }
   `;
@@ -67,11 +76,25 @@ export function UnskewedVideoMesh({ ...props }: ThreeElements['mesh']) {
   }, [videoDimensions]);
 
   // Create stable uniforms object that won't be recreated
+  const distCoeffsVec4 = useMemo(
+    () =>
+      new THREE.Vector4(
+        calibration.distortion_coefficients[0] ?? 0,
+        calibration.distortion_coefficients[1] ?? 0,
+        calibration.distortion_coefficients[2] ?? 0,
+        calibration.distortion_coefficients[3] ?? 0
+      ),
+    [calibration]
+  );
+  const k3 = calibration.distortion_coefficients[4] ?? 0;
+
   const uniforms = useMemo(
     () => ({
       videoTexture: { value: videoTexture },
-      mapXTexture: { value: mapXTexture },
-      mapYTexture: { value: mapYTexture },
+      cameraMatrix: { value: calibration.calibration_matrix },
+      newCameraMatrix: { value: calibration.new_camera_matrix },
+      distCoeffs: { value: distCoeffsVec4 },
+      k3: { value: k3 },
       resolution: { value: new THREE.Vector2(videoDimensions[0], videoDimensions[1]) },
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -81,10 +104,12 @@ export function UnskewedVideoMesh({ ...props }: ThreeElements['mesh']) {
   // Update uniform values when dependencies change
   useEffect(() => {
     uniforms.videoTexture.value = videoTexture;
-    uniforms.mapXTexture.value = mapXTexture;
-    uniforms.mapYTexture.value = mapYTexture;
+    uniforms.cameraMatrix.value = calibration.calibration_matrix;
+    uniforms.newCameraMatrix.value = calibration.new_camera_matrix;
+    uniforms.distCoeffs.value.copy(distCoeffsVec4);
+    uniforms.k3.value = k3;
     uniforms.resolution.value.set(videoDimensions[0], videoDimensions[1]);
-  }, [videoTexture, mapXTexture, mapYTexture, videoDimensions, uniforms]);
+  }, [videoTexture, videoDimensions, calibration, distCoeffsVec4, k3, uniforms]);
 
   return (
     <mesh {...props} geometry={planeGeometry}>


### PR DESCRIPTION
## Summary
- remove precomputed map textures
- inline undistortion computation in `CameraShaderMaterial`
- use shader-based undistort for `UnskewTsl`

## Testing
- `pnpm run format`
- `pnpm run build --filter @wbcnc/camNC` *(fails: Cannot find module './depthPipeline')*
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68667756e1708320961e34712ea7ea08