### PR TITLE
fix(camNC) avoid ONNX session mismatch

### DIFF
--- a/apps/camNC/src/depth/videoPipeline.worker.ts
+++ b/apps/camNC/src/depth/videoPipeline.worker.ts
@@ -273,16 +273,21 @@ class VideoPipelineWorker implements VideoPipelineWorkerAPI {
 
   private running = false;
   private cb: any = null;
+  private loopPromise: Promise<void> | null = null;
 
   async start(cb: any): Promise<void> {
     this.cb = cb;
     if (this.running) return;
+    if (this.loopPromise) await this.loopPromise;
     this.running = true;
-    this.loop();
+    this.loopPromise = this.loop();
   }
 
   async stop(): Promise<void> {
+    if (!this.running) return;
     this.running = false;
+    await this.loopPromise;
+    this.loopPromise = null;
   }
 
   private async loop() {


### PR DESCRIPTION
## Summary
- manage worker loop lifecycle to prevent overlapping depth processes

## Testing
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_686f6951bc0883209801504bd07804b5