### PR TITLE
feat(camNC) show PnP info and clean logs

### DIFF
--- a/apps/camNC/package.json
+++ b/apps/camNC/package.json
@@ -65,6 +65,7 @@
     "react-hook-form": "catalog:",
     "react-hotkeys-hook": "catalog:",
     "react-konva": "catalog:",
+    "react-timeago": "^8.2.0",
     "react-zoom-pan-pinch": "catalog:",
     "superjson": "catalog:",
     "suspend-react": "catalog:",

--- a/apps/camNC/src/calibration/solveP3P.ts
+++ b/apps/camNC/src/calibration/solveP3P.ts
@@ -56,7 +56,6 @@ export function computeP3P(mp: Vector3[], markersInCam: Vector2[], newCamMatrix:
   const reprojectedPoints = new cv2.Mat();
   cv2.projectPoints(objectPoints, rvec, tvec, cameraMatrix, distCoeffs, reprojectedPoints);
   const reprojectionError = computeReprojectionError(reprojectedPoints, markersInCam);
-  console.log('reprojectionError', reprojectionError);
   // Convert rotation vector to rotation matrix
   const R = new cv2.Mat();
   cv2.Rodrigues(rvec, R);

--- a/apps/camNC/src/setup/detect-aruco.ts
+++ b/apps/camNC/src/setup/detect-aruco.ts
@@ -23,7 +23,7 @@ export type IMarker = {
 
 // Returns markers in camera coordinates. Returns markers in order of id.
 export function detectAruco(img: cv2.Mat) {
-  const startTime = performance.now();
+  // const startTime = performance.now();
 
   // Convert to grayscale for detection
   const gray = new cv2.Mat();
@@ -40,9 +40,9 @@ export function detectAruco(img: cv2.Mat) {
   detector.detectMarkers(gray, corners, ids, rejected);
 
   // Measure processing time
-  const currentTime = performance.now() - startTime;
-  console.log(`Detection time: ${currentTime} ms`);
-  console.log(`Detected ${ids.rows} markers ${ids.rows} ids, ${rejected.size()} rejected`);
+  // const currentTime = performance.now() - startTime;
+  // console.log(`Detection time: ${currentTime} ms`);
+  // console.log(`Detected ${ids.rows} markers ${ids.rows} ids, ${rejected.size()} rejected`);
 
   const markers: IMarker[] = [];
   for (let i = 0; i < corners.size(); i++) {

--- a/apps/camNC/src/store/store-p3p.ts
+++ b/apps/camNC/src/store/store-p3p.ts
@@ -34,10 +34,11 @@ function computeMarkerP3P() {
 }
 
 export function updateCameraExtrinsics() {
-  const { setExtrinsics, setPnPResult } = useStore.getState().camSourceSetters;
+  const { setExtrinsics } = useStore.getState().camSourceSetters;
+  const { setPnPResult } = useStore.getState();
   const { R, t, reprojectionError } = computeMarkerP3P();
   setExtrinsics({ R, t });
-  setPnPResult(reprojectionError);
+  setPnPResult(Date.now(), reprojectionError);
   return reprojectionError;
 }
 

--- a/apps/camNC/src/store/store-p3p.ts
+++ b/apps/camNC/src/store/store-p3p.ts
@@ -34,10 +34,10 @@ function computeMarkerP3P() {
 }
 
 export function updateCameraExtrinsics() {
-  const setCameraExtrinsics = useStore.getState().camSourceSetters.setExtrinsics;
+  const { setExtrinsics, setPnPResult } = useStore.getState().camSourceSetters;
   const { R, t, reprojectionError } = computeMarkerP3P();
-  console.log('updated camera extrinsics', R, t, reprojectionError);
-  setCameraExtrinsics({ R, t });
+  setExtrinsics({ R, t });
+  setPnPResult(reprojectionError);
   return reprojectionError;
 }
 

--- a/apps/camNC/src/store/store.ts
+++ b/apps/camNC/src/store/store.ts
@@ -48,6 +48,10 @@ export interface ICamSource {
   markerPositions?: Vector3[];
   // ArUco marker configuration
   arucoTagSize?: number; // Size in mm of black border (excluding white border)
+  // Last time PnP was computed (ms since epoch)
+  lastPnPTime?: number;
+  // Last reprojection error in pixels
+  lastReprojectionError?: number;
 }
 
 superjson.registerCustom<Box2, { min: number[]; max: number[] }>(
@@ -156,6 +160,12 @@ export const useStore = create(persist(immer(combine(
         if (!state.camSource) throw new Error('configure source first');
         state.camSource.extrinsics = extrinsics;
       }),
+      setPnPResult: (error: number) =>
+        set(state => {
+          if (!state.camSource) throw new Error('configure source first');
+          state.camSource.lastPnPTime = Date.now();
+          state.camSource.lastReprojectionError = error;
+        }),
       setMachineBounds: (xmin: number, ymin: number, xmax: number, ymax: number) => set(state => {
         if (!state.camSource) throw new Error('configure source first');
         state.camSource.machineBounds = new Box2(new Vector2(xmin, ymin), new Vector2(xmax, ymax));
@@ -277,6 +287,8 @@ export function useMachineSize() {
 
 export const useCameraExtrinsics = () => useStore(state => state.camSource!.extrinsics!);
 export const useSetCameraExtrinsics = () => useStore(state => state.camSourceSetters.setExtrinsics);
+export const useLastPnPTime = () => useStore(state => state.camSource?.lastPnPTime);
+export const useReprojectionError = () => useStore(state => state.camSource?.lastReprojectionError);
 
 export const useShowStillFrame = () => useStore(state => state.showStillFrame);
 export const useSetShowStillFrame = () => useStore(state => state.setShowStillFrame);

--- a/apps/camNC/src/visualize/BoundsInfo.tsx
+++ b/apps/camNC/src/visualize/BoundsInfo.tsx
@@ -31,7 +31,11 @@ export function BoundsInfo() {
             <div>
               PnP computed <TimeAgo date={pnpResult.lastPnPTime} />
             </div>
-            {pnpResult.lastReprojectionError !== undefined && <div>Reprojection error: {pnpResult.lastReprojectionError.toFixed(2)}px</div>}
+            {pnpResult.lastReprojectionError !== undefined && (
+              <div className={pnpResult.lastReprojectionError > 2 ? 'text-red-600' : ''}>
+                Reprojection error: {pnpResult.lastReprojectionError.toFixed(2)}px
+              </div>
+            )}
           </div>
         </>
       )}

--- a/apps/camNC/src/visualize/BoundsInfo.tsx
+++ b/apps/camNC/src/visualize/BoundsInfo.tsx
@@ -1,30 +1,39 @@
+import { usePnPResult, useStore } from '@/store/store';
 import TimeAgo from 'react-timeago';
-import { useLastPnPTime, useReprojectionError, useStore } from '@/store/store';
 
 export function BoundsInfo() {
   const bounds = useStore(s => s.toolpath?.getBounds());
-  const lastPnP = useLastPnPTime();
-  const reproErr = useReprojectionError();
-  if (!bounds) return null;
+  const pnpResult = usePnPResult();
   return (
     <div className="flex flex-col gap-2">
       <h3 className="text-sm font-medium">Toolpath Bounds</h3>
-      <div className="grid gap-0.5 text-xs text-gray-600">
-        <div>
-          X: [{bounds.min.x.toFixed(2)}, {bounds.max.x.toFixed(2)}]
-        </div>
-        <div>
-          Y: [{bounds.min.y.toFixed(2)}, {bounds.max.y.toFixed(2)}]
-        </div>
-        <div>
-          Z: [{bounds.min.z.toFixed(2)}, {bounds.max.z.toFixed(2)}]
-        </div>
-      </div>
-      {lastPnP && (
-        <div className="text-xs mt-1">
-          PnP computed <TimeAgo date={lastPnP} />
-          {typeof reproErr === 'number' && <> – error: {reproErr.toFixed(2)}px</>}
-        </div>
+      {bounds ? (
+        <>
+          <div className="grid gap-0.5 text-xs text-gray-600">
+            <div>
+              X: [{bounds.min.x.toFixed(2)}, {bounds.max.x.toFixed(2)}]
+            </div>
+            <div>
+              Y: [{bounds.min.y.toFixed(2)}, {bounds.max.y.toFixed(2)}]
+            </div>
+            <div>
+              Z: [{bounds.min.z.toFixed(2)}, {bounds.max.z.toFixed(2)}]
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="text-xs text-gray-600">No toolpath loaded</div>
+      )}
+      {pnpResult && (
+        <>
+          <h3 className="text-sm font-medium">PnP</h3>
+          <div className="grid items-center gap-0.5 text-xs">
+            <div>
+              PnP computed <TimeAgo date={pnpResult.lastPnPTime} />
+            </div>
+            {pnpResult.lastReprojectionError !== undefined && <div>Reprojection error: {pnpResult.lastReprojectionError.toFixed(2)}px</div>}
+          </div>
+        </>
       )}
     </div>
   );

--- a/apps/camNC/src/visualize/BoundsInfo.tsx
+++ b/apps/camNC/src/visualize/BoundsInfo.tsx
@@ -1,7 +1,10 @@
-import { useStore } from '@/store/store';
+import TimeAgo from 'react-timeago';
+import { useLastPnPTime, useReprojectionError, useStore } from '@/store/store';
 
 export function BoundsInfo() {
   const bounds = useStore(s => s.toolpath?.getBounds());
+  const lastPnP = useLastPnPTime();
+  const reproErr = useReprojectionError();
   if (!bounds) return null;
   return (
     <div className="flex flex-col gap-2">
@@ -17,6 +20,12 @@ export function BoundsInfo() {
           Z: [{bounds.min.z.toFixed(2)}, {bounds.max.z.toFixed(2)}]
         </div>
       </div>
+      {lastPnP && (
+        <div className="text-xs mt-1">
+          PnP computed <TimeAgo date={lastPnP} />
+          {typeof reproErr === 'number' && <> – error: {reproErr.toFixed(2)}px</>}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/camNC/src/visualize/toolbar/VisualizeToolbar.tsx
+++ b/apps/camNC/src/visualize/toolbar/VisualizeToolbar.tsx
@@ -219,7 +219,7 @@ function BoundsInfoButton() {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <div>
-          <TooltipIconButton label="Bounds Info" icon={<Info />} shortcut="i" onClick={() => setOpen(true)} />
+          <TooltipIconButton label="Info" icon={<Info />} shortcut="i" onClick={() => setOpen(true)} />
         </div>
       </PopoverTrigger>
       <PopoverContent>

--- a/apps/camNC/src/visualize/toolbar/VisualizeToolbar.tsx
+++ b/apps/camNC/src/visualize/toolbar/VisualizeToolbar.tsx
@@ -212,9 +212,7 @@ function ColorLegendButton() {
 }
 
 function BoundsInfoButton() {
-  const hasToolpath = useHasToolpath();
   const [open, setOpen] = useState(false);
-  if (!hasToolpath) return null;
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>

--- a/apps/camNC/src/workers/markerScanner.worker.ts
+++ b/apps/camNC/src/workers/markerScanner.worker.ts
@@ -81,8 +81,6 @@ class MarkerScannerWorker implements MarkerScannerWorkerAPI {
   }
 
   async scan(): Promise<IMarker[]> {
-    console.debug('scanning markers in worker');
-
     if (!this.reader || !this.mapX || !this.mapY || !this.ctx) {
       throw new Error('Worker not initialized');
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,6 +546,9 @@ importers:
       react-konva:
         specifier: 'catalog:'
         version: 19.0.4(@types/react@19.1.6)(konva@9.3.20)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-timeago:
+        specifier: ^8.2.0
+        version: 8.2.0(react@19.1.0)
       react-zoom-pan-pinch:
         specifier: 'catalog:'
         version: 3.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -6101,6 +6104,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-timeago@8.2.0:
+    resolution: {integrity: sha512-RWDlG3Jj+iwv+yNEDweA/Qk1mxE8i/Oc4oW8Irp29ZfBp+eNpqqYPMLPYQJyfRMJcGB8CmWkEGMYhB4fW8eZlQ==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-use-measure@2.1.7:
     resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
@@ -12406,6 +12414,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.6
+
+  react-timeago@8.2.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   react-use-measure@2.1.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Summary
- add react-timeago to show when PnP was last computed
- track PnP timestamp and error in store
- display PnP info in `BoundsInfo`
- rename "Bounds Info" button to "Info"
- remove verbose PnP logs

## Testing
- `pnpm run format`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6870bec3c4fc83209140137981beead2