### PR TITLE
feat(camNC): Snap-to-toolpath cursor

### DIFF
--- a/apps/camNC/src/routes/visualize/2DView.tsx
+++ b/apps/camNC/src/routes/visualize/2DView.tsx
@@ -5,15 +5,17 @@ import { useInitToolpathOffset } from '@/hooks/useInitToolpathOffset';
 import { getCncApi } from '@/lib/fluidnc/fluidnc-singleton';
 import { PresentCanvas } from '@/scene/PresentCanvas';
 import { MachinePositionMarker } from '@/visualize/MachinePositionMarker';
+import { SnapPositionMarker } from '@/visualize/SnapPositionMarker';
 import { MachineZeroAxes } from '@/visualize/MachineZeroAxes';
 import { GCodeVisualizer } from '@/visualize/Toolpaths';
 import { VisualizeToolbar } from '@/visualize/toolbar/VisualizeToolbar';
+import { nearestPointOnToolpath } from '@/visualize/nearestPoint';
 import { ThreeElements, ThreeEvent } from '@react-three/fiber';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { PageHeader } from '@wbcnc/ui/components/page-header';
 import { toast } from '@wbcnc/ui/components/sonner';
-import { Vector2 } from 'three';
-import { useStore } from '../../store/store';
+import { Vector2, Vector3 } from 'three';
+import { useStore, useSnapToToolpath, useSetSnapPosition, useSnapPosition } from '../../store/store';
 
 export const Route = createFileRoute('/visualize/2DView')({
   component: VisualizeComponent,
@@ -35,6 +37,11 @@ function VisualizeComponent() {
   useInitToolpathOffset();
   const cncApi = getCncApi();
   useAutoScanMarkers({ intervalMs: 3_000 });
+  const snapEnabled = useSnapToToolpath();
+  const setSnapPosition = useSetSnapPosition();
+  const snapPos = useSnapPosition();
+  const toolpath = useStore(s => s.toolpath);
+  const toolpathOffset = useStore(s => s.toolpathOffset);
 
   function onDbClick(event: ThreeEvent<MouseEvent>) {
     console.log('onDbClick', event.unprojectedPoint);
@@ -53,6 +60,34 @@ function VisualizeComponent() {
     toast.success(`Jogging to ${point.x.toFixed(2)}, ${point.y.toFixed(2)}`);
   }
 
+  function onPointerMove(event: ThreeEvent<PointerEvent>) {
+    if (!snapEnabled || !toolpath) {
+      setSnapPosition(null);
+      return;
+    }
+    const point = event.unprojectedPoint as Vector3;
+    const nearest = nearestPointOnToolpath(toolpath, point, toolpathOffset);
+    setSnapPosition(nearest);
+  }
+
+  function onClickSnap() {
+    if (!snapEnabled) return;
+    const pos = snapPos;
+    if (!pos) return;
+    if (!cncApi?.isConnected()) {
+      toast.error('FluicNC integration not connected');
+      return;
+    }
+    const bounds = useStore.getState().camSource?.machineBounds;
+    if (!bounds) return;
+    if (!bounds.containsPoint(new Vector2(pos.x, pos.y))) {
+      toast.info('Cannot jog outside machine bounds');
+      return;
+    }
+    cncApi.jogToMachineCoordinates(pos.x, pos.y);
+    toast.success(`Jogging to ${pos.x.toFixed(2)}, ${pos.y.toFixed(2)}`);
+  }
+
   return (
     <div className="relative w-full h-full">
       <DepthBlendWorker />
@@ -64,9 +99,10 @@ function VisualizeComponent() {
       <div className="w-full h-dvh absolute top-0 left-0">
         <PresentCanvas worldScale="machine">
           {/* <group rotation={[0, 0, Math.PI / 2]}> */}
-          <UnprojectVideoMeshWithStockHeight onDoubleClick={onDbClick} />
+          <UnprojectVideoMeshWithStockHeight onDoubleClick={onDbClick} onPointerMove={onPointerMove} onClick={onClickSnap} />
           <GCodeVisualizer />
           <MachinePositionMarker />
+          <SnapPositionMarker />
           <MachineZeroAxes />
           {/* </group> */}
 

--- a/apps/camNC/src/routes/visualize/2DView.tsx
+++ b/apps/camNC/src/routes/visualize/2DView.tsx
@@ -5,17 +5,18 @@ import { useInitToolpathOffset } from '@/hooks/useInitToolpathOffset';
 import { getCncApi } from '@/lib/fluidnc/fluidnc-singleton';
 import { PresentCanvas } from '@/scene/PresentCanvas';
 import { MachinePositionMarker } from '@/visualize/MachinePositionMarker';
-import { SnapPositionMarker } from '@/visualize/SnapPositionMarker';
 import { MachineZeroAxes } from '@/visualize/MachineZeroAxes';
+import { SnapPositionMarker } from '@/visualize/SnapPositionMarker';
 import { GCodeVisualizer } from '@/visualize/Toolpaths';
-import { VisualizeToolbar } from '@/visualize/toolbar/VisualizeToolbar';
 import { nearestPointOnToolpath } from '@/visualize/nearestPoint';
+import { VisualizeToolbar } from '@/visualize/toolbar/VisualizeToolbar';
 import { ThreeElements, ThreeEvent } from '@react-three/fiber';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { PageHeader } from '@wbcnc/ui/components/page-header';
 import { toast } from '@wbcnc/ui/components/sonner';
+import { useHotkeys } from 'react-hotkeys-hook';
 import { Vector2, Vector3 } from 'three';
-import { useStore, useSnapToToolpath, useSetSnapPosition, useSnapPosition } from '../../store/store';
+import { useSetSnapPosition, useSetSnapToToolpath, useSnapPosition, useSnapToToolpath, useStore } from '../../store/store';
 
 export const Route = createFileRoute('/visualize/2DView')({
   component: VisualizeComponent,
@@ -40,10 +41,23 @@ function VisualizeComponent() {
   const snapEnabled = useSnapToToolpath();
   const setSnapPosition = useSetSnapPosition();
   const snapPos = useSnapPosition();
+  const setSnapToToolpath = useSetSnapToToolpath();
   const toolpath = useStore(s => s.toolpath);
   const toolpathOffset = useStore(s => s.toolpathOffset);
 
+  // Disable snap-to-toolpath mode when user presses ESC
+  useHotkeys(
+    'esc',
+    () => {
+      if (snapEnabled) {
+        setSnapToToolpath(false);
+      }
+    },
+    [snapEnabled]
+  );
+
   function onDbClick(event: ThreeEvent<MouseEvent>) {
+    if (!snapEnabled) return onClickSnap();
     console.log('onDbClick', event.unprojectedPoint);
     if (!cncApi?.isConnected()) {
       toast.error('FluicNC integration not connected');
@@ -99,7 +113,7 @@ function VisualizeComponent() {
       <div className="w-full h-dvh absolute top-0 left-0">
         <PresentCanvas worldScale="machine">
           {/* <group rotation={[0, 0, Math.PI / 2]}> */}
-          <UnprojectVideoMeshWithStockHeight onDoubleClick={onDbClick} onPointerMove={onPointerMove} onClick={onClickSnap} />
+          <UnprojectVideoMeshWithStockHeight onDoubleClick={onDbClick} onPointerMove={onPointerMove} />
           <GCodeVisualizer />
           <MachinePositionMarker />
           <SnapPositionMarker />

--- a/apps/camNC/src/store/store.ts
+++ b/apps/camNC/src/store/store.ts
@@ -126,6 +126,8 @@ export const useStore = create(persist(immer(combine(
     showMachineZero: true,
     showStillFrame: false,
     fluidncToken: crypto.randomUUID() as string,
+    snapToToolpath: false,
+    snapPosition: null as Vector3 | null,
     // Depth-based background blend feature
     depthBlendEnabled: false,
     depthMaskTexture: null as Texture | null,
@@ -211,6 +213,12 @@ export const useStore = create(persist(immer(combine(
     }),
     setFluidncToken: (token: string) => set(state => {
       state.fluidncToken = token;
+    }),
+    setSnapToToolpath: (enable: boolean) => set(state => {
+      state.snapToToolpath = enable;
+    }),
+    setSnapPosition: (pos: Vector3 | null) => set(state => {
+      state.snapPosition = pos;
     }),
     // Depth blend feature setters
     setDepthBlendEnabled: (enabled: boolean) => {
@@ -320,3 +328,7 @@ export const useShowMachinePosMarker = () => useStore(state => state.showMachine
 export const useSetShowMachinePosMarker = () => useStore(state => state.setShowMachinePosMarker);
 export const useShowMachineZero = () => useStore(state => state.showMachineZero);
 export const useSetShowMachineZero = () => useStore(state => state.setShowMachineZero);
+export const useSnapToToolpath = () => useStore(state => state.snapToToolpath);
+export const useSetSnapToToolpath = () => useStore(state => state.setSnapToToolpath);
+export const useSnapPosition = () => useStore(state => state.snapPosition);
+export const useSetSnapPosition = () => useStore(state => state.setSnapPosition);

--- a/apps/camNC/src/visualize/SnapPositionMarker.tsx
+++ b/apps/camNC/src/visualize/SnapPositionMarker.tsx
@@ -1,0 +1,90 @@
+import { useSnapPosition, useToolDiameter, useSnapToToolpath } from '@/store/store';
+import { animated, easings, useSpring } from '@react-spring/three';
+import { Line } from '@react-three/drei';
+import { useMemo } from 'react';
+
+export function SnapPositionMarker({
+  opacity = 0.7,
+  innerColor = '#00ffff',
+  dashColor = '#ff0000',
+}: {
+  opacity?: number;
+  innerColor?: string;
+  dashColor?: string;
+}) {
+  'use no memo';
+
+  const enabled = useSnapToToolpath();
+  const position = useSnapPosition();
+  const toolDiameter = useToolDiameter();
+
+  const radius = toolDiameter / 2;
+  const lineThickness = Math.max(radius * 0.05, 1);
+  const ringRadius = Math.max(radius, 6) * 1.35;
+
+  const innerCirclePoints = useMemo(() => {
+    const segments = 128;
+    const pts: [number, number, number][] = [];
+    for (let i = 0; i <= segments; i++) {
+      const theta = (i / segments) * Math.PI * 2;
+      pts.push([Math.cos(theta) * radius, Math.sin(theta) * radius, 0]);
+    }
+    return pts;
+  }, [radius]);
+
+  const { rot } = useSpring({
+    from: { rot: 0 },
+    to: { rot: Math.PI * 2 },
+    loop: true,
+    config: { duration: 4000, easing: easings.linear },
+  });
+
+  const segmentPairs = 12;
+  const arcSegments = useMemo(() => {
+    const segmentsPerArc = 12;
+    const arcs: { points: [number, number, number][]; color: string }[] = [];
+    const anglePerSegment = (Math.PI * 2) / segmentPairs;
+    for (let s = 0; s < segmentPairs; s++) {
+      const color = s % 2 === 0 ? innerColor : dashColor;
+      const startAngle = s * anglePerSegment;
+      const pts: [number, number, number][] = [];
+      for (let i = 0; i <= segmentsPerArc; i++) {
+        const theta = startAngle + (i / segmentsPerArc) * anglePerSegment;
+        pts.push([Math.cos(theta) * ringRadius, Math.sin(theta) * ringRadius, 0]);
+      }
+      arcs.push({ points: pts, color });
+    }
+    return arcs;
+  }, [ringRadius, innerColor, dashColor]);
+
+  const zElev = 30;
+
+  if (!enabled || !position) return null;
+
+  return (
+    <group position={[position.x, position.y, zElev]} renderOrder={1000}>
+      <Line
+        points={[
+          [-radius, 0, 0],
+          [radius, 0, 0],
+        ]}
+        color={innerColor}
+        linewidth={lineThickness}
+      />
+      <Line
+        points={[
+          [0, -radius, 0],
+          [0, radius, 0],
+        ]}
+        color={innerColor}
+        linewidth={lineThickness}
+      />
+      <Line points={innerCirclePoints} color={innerColor} transparent opacity={opacity} linewidth={lineThickness} />
+      <animated.group rotation-z={rot}>
+        {arcSegments.map(({ points, color }, idx) => (
+          <Line key={idx} points={points} color={color} linewidth={lineThickness} />
+        ))}
+      </animated.group>
+    </group>
+  );
+}

--- a/apps/camNC/src/visualize/nearestPoint.ts
+++ b/apps/camNC/src/visualize/nearestPoint.ts
@@ -2,10 +2,20 @@ import { Vector3 } from 'three';
 import { ParsedToolpath } from './gcodeParsing';
 
 function closestPointOnSegment(a: Vector3, b: Vector3, p: Vector3): Vector3 {
-  const ab = new Vector3().subVectors(b, a);
-  const t = ((p.x - a.x) * ab.x + (p.y - a.y) * ab.y + (p.z - a.z) * ab.z) / ab.lengthSq();
+  // Compute the closest point ignoring the z-axis (operate in the XY-plane only)
+  const abX = b.x - a.x;
+  const abY = b.y - a.y;
+  const abLenSq = abX * abX + abY * abY;
+
+  if (abLenSq === 0) {
+    return a.clone();
+  }
+
+  const t = ((p.x - a.x) * abX + (p.y - a.y) * abY) / abLenSq;
   const clamped = Math.max(0, Math.min(1, t));
-  return new Vector3(a.x + ab.x * clamped, a.y + ab.y * clamped, a.z + ab.z * clamped);
+
+  // Interpolate x & y; keep z interpolated along the original segment (does not affect distance)
+  return new Vector3(a.x + abX * clamped, a.y + abY * clamped, a.z + (b.z - a.z) * clamped);
 }
 
 export function nearestPointOnToolpath(toolpath: ParsedToolpath, point: Vector3, offset: Vector3): Vector3 {
@@ -15,7 +25,10 @@ export function nearestPointOnToolpath(toolpath: ParsedToolpath, point: Vector3,
     const p0 = toolpath.pathPoints[i - 1].clone().add(offset);
     const p1 = toolpath.pathPoints[i].clone().add(offset);
     const c = closestPointOnSegment(p0, p1, point);
-    const d = c.distanceToSquared(point);
+    // Distance in the XY-plane only (ignore z)
+    const dx = c.x - point.x;
+    const dy = c.y - point.y;
+    const d = dx * dx + dy * dy;
     if (d < minDist) {
       minDist = d;
       nearest.copy(c);

--- a/apps/camNC/src/visualize/nearestPoint.ts
+++ b/apps/camNC/src/visualize/nearestPoint.ts
@@ -1,0 +1,25 @@
+import { Vector3 } from 'three';
+import { ParsedToolpath } from './gcodeParsing';
+
+function closestPointOnSegment(a: Vector3, b: Vector3, p: Vector3): Vector3 {
+  const ab = new Vector3().subVectors(b, a);
+  const t = ((p.x - a.x) * ab.x + (p.y - a.y) * ab.y + (p.z - a.z) * ab.z) / ab.lengthSq();
+  const clamped = Math.max(0, Math.min(1, t));
+  return new Vector3(a.x + ab.x * clamped, a.y + ab.y * clamped, a.z + ab.z * clamped);
+}
+
+export function nearestPointOnToolpath(toolpath: ParsedToolpath, point: Vector3, offset: Vector3): Vector3 {
+  const nearest = new Vector3();
+  let minDist = Infinity;
+  for (let i = 1; i < toolpath.pathPoints.length; i++) {
+    const p0 = toolpath.pathPoints[i - 1].clone().add(offset);
+    const p1 = toolpath.pathPoints[i].clone().add(offset);
+    const c = closestPointOnSegment(p0, p1, point);
+    const d = c.distanceToSquared(point);
+    if (d < minDist) {
+      minDist = d;
+      nearest.copy(c);
+    }
+  }
+  return nearest;
+}

--- a/apps/camNC/src/visualize/toolbar/FluidncButton.tsx
+++ b/apps/camNC/src/visualize/toolbar/FluidncButton.tsx
@@ -3,11 +3,11 @@ import {
   useHasToolpath,
   useSetShowMachinePosMarker,
   useSetShowMachineZero,
+  useSetSnapToToolpath,
   useShowMachinePosMarker,
   useShowMachineZero,
-  useStore,
   useSnapToToolpath,
-  useSetSnapToToolpath,
+  useStore,
 } from '@/store/store';
 import { Link } from '@tanstack/react-router';
 import {
@@ -19,7 +19,7 @@ import {
   DropdownMenuTrigger,
 } from '@wbcnc/ui/components/dropdown-menu';
 import { toast } from '@wbcnc/ui/components/sonner';
-import { CircleArrowRight, CircleOff, ClipboardCopy, Download, Eye, EyeOff, Joystick, Puzzle, Crosshair } from 'lucide-react';
+import { CircleArrowRight, CircleOff, ClipboardCopy, Crosshair, Download, Eye, EyeOff, Joystick, Puzzle } from 'lucide-react';
 import { Vector3 } from 'three';
 import { TooltipIconButton } from './TooltipIconButton';
 import { UploadMenuItem } from './UploadMenuItem';
@@ -112,7 +112,7 @@ export function FluidncButton() {
         <DropdownMenuItem onClick={() => setShowMachineZero(!showMachineZero)}>
           {showMachineZero ? <EyeOff /> : <Eye />} {showMachineZero ? 'Hide' : 'Show'} zero axes
         </DropdownMenuItem>
-        <DropdownMenuItem disabled={!isFluidAvailable} onClick={() => setSnapToToolpath(!snapToToolpath)}>
+        <DropdownMenuItem onClick={() => setSnapToToolpath(!snapToToolpath)}>
           <Crosshair /> {snapToToolpath ? 'Disable' : 'Enable'} snap to toolpath
         </DropdownMenuItem>
         <DropdownMenuSeparator />

--- a/apps/camNC/src/visualize/toolbar/FluidncButton.tsx
+++ b/apps/camNC/src/visualize/toolbar/FluidncButton.tsx
@@ -6,6 +6,8 @@ import {
   useShowMachinePosMarker,
   useShowMachineZero,
   useStore,
+  useSnapToToolpath,
+  useSetSnapToToolpath,
 } from '@/store/store';
 import { Link } from '@tanstack/react-router';
 import {
@@ -17,7 +19,7 @@ import {
   DropdownMenuTrigger,
 } from '@wbcnc/ui/components/dropdown-menu';
 import { toast } from '@wbcnc/ui/components/sonner';
-import { CircleArrowRight, CircleOff, ClipboardCopy, Download, Eye, EyeOff, Joystick, Puzzle } from 'lucide-react';
+import { CircleArrowRight, CircleOff, ClipboardCopy, Download, Eye, EyeOff, Joystick, Puzzle, Crosshair } from 'lucide-react';
 import { Vector3 } from 'three';
 import { TooltipIconButton } from './TooltipIconButton';
 import { UploadMenuItem } from './UploadMenuItem';
@@ -73,6 +75,8 @@ export function FluidncButton() {
   const setShowMachinePosMarker = useSetShowMachinePosMarker();
   const showMachineZero = useShowMachineZero();
   const setShowMachineZero = useSetShowMachineZero();
+  const snapToToolpath = useSnapToToolpath();
+  const setSnapToToolpath = useSetSnapToToolpath();
 
   return (
     <DropdownMenu>
@@ -107,6 +111,9 @@ export function FluidncButton() {
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setShowMachineZero(!showMachineZero)}>
           {showMachineZero ? <EyeOff /> : <Eye />} {showMachineZero ? 'Hide' : 'Show'} zero axes
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={!isFluidAvailable} onClick={() => setSnapToToolpath(!snapToToolpath)}>
+          <Crosshair /> {snapToToolpath ? 'Disable' : 'Enable'} snap to toolpath
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>


### PR DESCRIPTION
## Summary
- enable Snap-to-toolpath mode in FluidNC dropdown
- track cursor in 2D view and snap to nearest toolpath point
- render a preview marker of snapped position
- jog machine to snapped point on click

## Testing
- `pnpm run format`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_687622d0235c8320a0ce693591e894d0