### PR TITLE
fix: allow db/prod users to exist in same table

### DIFF
--- a/apps/camNC/package.json
+++ b/apps/camNC/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "push-db": "npx drizzle-kit push",
     "lint": "eslint . --max-warnings 0",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/apps/camNC/src/db/schema.ts
+++ b/apps/camNC/src/db/schema.ts
@@ -4,5 +4,5 @@ export const users = pgTable('users', {
   id: varchar({ length: 255 }).primaryKey(),
   settings: jsonb().$type<Record<string, any>>().notNull().default({ foo: 'bar' }),
   name: varchar({ length: 255 }).notNull(),
-  email: varchar({ length: 255 }).notNull().unique(),
+  email: varchar({ length: 255 }).notNull(),
 });


### PR DESCRIPTION
This PR updates the database schema and related code to allow both db and prod users to exist in the same users table. See schema and logic changes in src/db/schema.ts and related files.