### PR TITLE
Fix error handling in useDepthBlendWorker and media-stream-processor-polyfil.ts

### DIFF
--- a/apps/camNC/src/hooks/useDepthBlendWorker.tsx
+++ b/apps/camNC/src/hooks/useDepthBlendWorker.tsx
@@ -12,7 +12,9 @@ import {
   useVideoUrl,
 } from '@/store/store';
 import { useVideoSource } from '@wbcnc/go2webrtc/use-video-source';
+import { toast } from '@wbcnc/ui/components/sonner';
 import { Suspense, useEffect, useMemo } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 
 function DepthBlendWorkerSuspending() {
   useDepthBlendWorker();
@@ -23,7 +25,14 @@ function DepthBlendWorkerSuspending() {
 export function DepthBlendWorker() {
   return (
     <Suspense fallback={null}>
-      <DepthBlendWorkerSuspending />
+      <ErrorBoundary
+        fallback={null}
+        onError={() => {
+          console.error('Error loading depth blend worker');
+          toast.error('Error loading depth blend worker', { duration: Infinity, closeButton: true });
+        }}>
+        <DepthBlendWorkerSuspending />
+      </ErrorBoundary>
     </Suspense>
   );
 }

--- a/packages/video-worker-utils/src/media-stream-processor-polyfil.ts
+++ b/packages/video-worker-utils/src/media-stream-processor-polyfil.ts
@@ -18,6 +18,7 @@ if (!globalThis.MediaStreamTrackProcessor && isFirefox) {
         this.readable = new ReadableStream({
           async start(controller) {
             this.video = document.createElement('video');
+            this.video.muted = true;
             this.video.srcObject = new MediaStream([track]);
             await Promise.all([this.video.play(), new Promise(r => (this.video.onloadedmetadata = r))]);
             this.track = track;


### PR DESCRIPTION
This PR improves error handling in the DepthBlendWorker React hook and the MediaStreamTrackProcessor polyfill.