### PR TITLE
fix(camNC): tooltips not showing with composite trigger

### DIFF
--- a/apps/camNC/src/visualize/toolbar/TooltipIconButton.tsx
+++ b/apps/camNC/src/visualize/toolbar/TooltipIconButton.tsx
@@ -22,15 +22,21 @@ export function TooltipIconButton({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button
-          {...(props as any)}
-          onPress={onClick}
-          aria-label={label}
-          variant="light"
-          size="sm"
-          className={cn('min-w-8 h-10 [&_svg:not([class*=size-])]:size-4', props.className)}>
-          {icon}
-        </Button>
+        {/*
+          Wrap the HeroUI Button so Radix TooltipTrigger gets a real DOM element.
+          Some composite components don't forward refs/handlers Radix relies on.
+        */}
+        <span className="inline-flex">
+          <Button
+            {...(props as any)}
+            onPress={onClick}
+            aria-label={label}
+            variant="light"
+            size="sm"
+            className={cn('min-w-8 h-10 [&_svg:not([class*=size-])]:size-4', props.className)}>
+            {icon}
+          </Button>
+        </span>
       </TooltipTrigger>
       <TooltipContent>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
Wrap HeroUI Button in a DOM element inside Radix `TooltipTrigger asChild` so hover/focus events reach Radix and tooltips render.