### PR TITLE
chore: limit ci permissions to read only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Schibum/camNC/security/code-scanning/1](https://github.com/Schibum/camNC/security/code-scanning/1)

To fix the problem, specify a `permissions` block with the least required privileges for either the entire workflow (at the root) or for the specific job. Since all jobs shown in this workflow only read repository contents and do not need to write to it, we can set `permissions: contents: read` at the top level (just after the workflow name, before `on:`), or we can add it at the job level under `test`. Adding it at the workflow root is cleaner, especially when all jobs require the same permissions.

The change required:  
Insert
```yaml
permissions:
  contents: read
```
after the workflow name and before the `on:` block (i.e., after line 1).

No additional definitions, imports, or logic changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
